### PR TITLE
Update template and instructions to pass in Kubernetes version

### DIFF
--- a/docs-site/content/en/docs/Deployment Options/custom-password-tls/index.md
+++ b/docs-site/content/en/docs/Deployment Options/custom-password-tls/index.md
@@ -49,14 +49,18 @@ Get the signed in user id so that you can get admin access to the cluster you cr
 
 ```bash
 SIGNEDINUSER=$(az ad signed-in-user show --query id --out tsv)
+```
+Setup deployment parameters
+```bash
+DEPLOYMENTREGION=eastus
+KUBERNETESVERSION=$(az aks get-versions -l $DEPLOYMENTREGION -o tsv --query "values[?contains(@.capabilities.supportPlan,'AKSLongTermSupport')].version")
 RGNAME=kubeflow
 ```
-
 Create deployment
 
 ```bash
-az group create -n $RGNAME -l eastus
-DEP=$(az deployment group create -g $RGNAME --parameters signedinuser=$SIGNEDINUSER -f main.bicep -o json)
+az group create -n $RGNAME -l $DEPLOYMENTREGION
+DEP=$(az deployment group create -g $RGNAME --parameters signedinuser=$SIGNEDINUSER kubernetesVersion=$KUBERNETESVERSION -f main.bicep -o json)
 ```
 {{< alert color="primary" >}}💡Note: The DEP variable is very important and will be used in subsequent steps. You can save it by running `echo $DEP > test.json` and restore it by running `export DEP=$(cat test.json)`.{{< /alert >}} 
 

--- a/docs-site/content/en/docs/Deployment Options/vanilla-installation/index.md
+++ b/docs-site/content/en/docs/Deployment Options/vanilla-installation/index.md
@@ -53,14 +53,18 @@ Get the signed in user id so that you can get admin access to the cluster you cr
 
 ```bash
 SIGNEDINUSER=$(az ad signed-in-user show --query id --out tsv)
+```
+Setup deployment parameters
+```bash
+DEPLOYMENTREGION=eastus
+KUBERNETESVERSION=$(az aks get-versions -l $DEPLOYMENTREGION -o tsv --query "values[?contains(@.capabilities.supportPlan,'AKSLongTermSupport')].version")
 RGNAME=kubeflow
 ```
-
 Create deployment
 
 ```bash
-az group create -n $RGNAME -l eastus
-DEP=$(az deployment group create -g $RGNAME --parameters signedinuser=$SIGNEDINUSER -f main.bicep -o json)
+az group create -n $RGNAME -l $DEPLOYMENTREGION
+DEP=$(az deployment group create -g $RGNAME --parameters signedinuser=$SIGNEDINUSER kubernetesVersion=$KUBERNETESVERSION -f main.bicep -o json)
 ```
 
 {{< alert color="primary" >}}💡Note: The DEP variable is very important and will be used in subsequent steps. You can save it by running `echo $DEP > test.json` and restore it by running `export DEP=$(cat test.json)`.{{< /alert >}} 

--- a/main.bicep
+++ b/main.bicep
@@ -1,6 +1,7 @@
 param nameseed string = 'kubeflow'
 param location string = resourceGroup().location
 param signedinuser string
+param kubernetesVersion string
 
 //---------Kubernetes Construction---------
 module aksconst './AKS-Construction/bicep/main.bicep' = {
@@ -24,6 +25,7 @@ module aksconst './AKS-Construction/bicep/main.bicep' = {
     AksDisableLocalAccounts: true
     custom_vnet: true
     upgradeChannel: 'stable'
+    kubernetesVersion: kubernetesVersion
 
     //Workload Identity requires OidcIssuer to be configured on AKS
     // oidcIssuer: true


### PR DESCRIPTION
Available versions of Kubernetes constantly change on Azure, this updates the instructions to use the latest available version in the region being deployed.

Alternatively we can track the main branch of AKS-Construction, which is being constantly updated, to simplify the instructions but that can cause other compativility issues.