### PR TITLE
Stop the docs edit links leaking the build machine's path

### DIFF
--- a/docs-site/config.toml
+++ b/docs-site/config.toml
@@ -112,6 +112,15 @@ github_repo = "https://github.com/Azure/kubeflow-aks"
 # Documentation content is maintained in docs/ at the repository root.
 github_subdir = "docs"
 
+# docs/ is mounted from outside the Hugo root (see [module] below), and for such
+# content Hugo reports an absolute path on the build machine rather than a
+# repository-relative one. Left alone, Docsy concatenates that onto
+# github_subdir and the "Edit this page" link becomes
+# .../edit/main/docs/home/runner/work/kubeflow-aks/kubeflow-aks/docs/README.md.
+# Strip everything up to and including the mounted directory so github_subdir
+# puts back the one repository-relative prefix that belongs there.
+path_base_for_github_subdir = { from = "^.*/docs/", to = "" }
+
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links
 github_branch = "main"


### PR DESCRIPTION
The three pages under docs/ are mounted into the site from outside the Hugo root, and for such content Hugo reports the file's absolute path on the build machine rather than its path in the repository. Docsy appends that to github_subdir, so "Edit this page" on the published site resolved to

  .../edit/main/docs/home/runner/work/kubeflow-aks/kubeflow-aks/docs/README.md

which 404s for a signed-in reader and publishes the runner's directory layout. "View this page" and "Create child page" were mangled the same way.

Set path_base_for_github_subdir, the knob Docsy provides for exactly this, to strip everything up to and including the mounted directory. github_subdir then supplies the one repository-relative prefix that belongs there, and the links resolve to docs/README.md, docs/custom-role.md and docs/user-authentication.md.